### PR TITLE
Fix amber host

### DIFF
--- a/frameworks/Crystal/amber/config/application.cr
+++ b/frameworks/Crystal/amber/config/application.cr
@@ -7,4 +7,5 @@ Amber::Server.configure do |app|
   app.name = "TFB test app"
   app.color = false
   app.port = 8080
+  app.host = "0.0.0.0"
 end


### PR DESCRIPTION
Hi @nbrady-techempower This PR tries to fix amber again. This time We suspect amber failure could be caused by amber running on wrong host (localhost) on TFB tests.

By example on [preview 2](http://tfb-logs.techempower.com/round-15/preview-2/amber/out.txt) (preview 3 failed) amber is running on host `0.0.0.0` but on latest tests on https://github.com/TechEmpower/FrameworkBenchmarks/issues/2960#issuecomment-347285042 amber was running on `127.0.0.1` aka. localhost. And because TFB tests are running on 3 machines setup, clients weren't able to found amber servers.
